### PR TITLE
Only print string if process was running in the first place.

### DIFF
--- a/after.c
+++ b/after.c
@@ -83,6 +83,9 @@ main(int argc, char *argv[])
 
 	verbose = 0;
 
+	if (pledge("stdio ps", NULL) == -1)
+		err(1, "pledge");
+
 	// argument parsing...
 	while((ch = getopt(argc, argv, "e:hn:p:v")) != -1)
 		switch(ch) {

--- a/after.c
+++ b/after.c
@@ -74,6 +74,7 @@ main(int argc, char *argv[])
 {
 	int i, ch, entries;
 	int pid = 0;
+	int found = 0;
 	char *pname = NULL, *cmd = NULL;
 	char errbuf[_POSIX2_LINE_MAX];
 
@@ -131,13 +132,19 @@ main(int argc, char *argv[])
 		pname_is_in(pname, kinfo, entries) == 0 :
 		pid_is_in(pid, kinfo, entries) == 0
         ) {
+		found = 1;
 		kinfo = get_proc_list(kd, &entries);
 		debug_print("waiting...");
 		sleep(1);
 	}
 
-	debug_print("process not in process list (died?).");
-	printf("%s\n", cmd);
+	if (found) {
+		debug_print("process died.");
+		printf("%s\n", cmd);
+	} else {
+		debug_print("process not in process list.");
+		exit(1);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
If it's not obvious i like this little tool. Great idea.

I'm unsure if this is better than the default behavior but for what I have in mind I'd like to know if the process was running or not in the first place.